### PR TITLE
Pagination feature for the student status table 

### DIFF
--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -16,17 +16,18 @@ import StudentsReadOnlyTable from "./StudentsReadOnlyTable";
 import ChaperonesTable from "./ChaperonesTable";
 import "./FieldTripDetails.css";
 
-const FieldTripDetails = ({ match } ) => {
+let perPage;
 
+const FieldTripDetails = ({ match } ) => {
   const [trip, setTrip] = useState({}); // local state
   const [students, setStudents] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [lastAddedStudentStatusID, setLastAddedStudentStatusID] = useState(null);
   const [chaperones, setChaperones] = useState([]);
   const [user] = useGlobal("user");
   const [parentList, setParentList] = useState([])
   const tripItemID = match.params.id;
-
-  let perPage;
 
   useEffect(() => {
     const url = `fieldtrips/${tripItemID}`
@@ -46,6 +47,7 @@ const FieldTripDetails = ({ match } ) => {
         // {completeStudentStatusesSorted, totalCount, totalPages}
         setStudents(data.completeStudentStatusesSorted);
         setTotalCount(data.totalCount);
+        setTotalPages(data.totalPages);
         perPage = data.perPage;
       })
       .catch(err => err);
@@ -116,23 +118,21 @@ const FieldTripDetails = ({ match } ) => {
         setIsSuccessfullyAdded(true);
         setError(false);
 
-        // const tripItemID = match.params.id;
-        // const statusUrl = `students_fieldtrips/${tripItemID}/statuses?sortBy=created_at&direction=desc`;
-        // api
-        //   .get(statusUrl)
-        //   .then(({ data }) => {
-        //     console.log("students ALL::", data);
-        //     setStudents(data.completeStudentStatusesSorted);
-        //     return setTotalCount(data.totalCount);
-        //   })
-        //   .catch(err => err);
-
-        const studentsMinusLastOne = students.slice(0, students.length - 1);
-        const updatedStudents = [data, ...studentsMinusLastOne];
-        setStudents(updatedStudents);
+        if (students.length < perPage) {
+          const updatedStudents = [data, ...students];
+          setStudents(updatedStudents);
+        } else {
+          // Slice when the perPage is 5 students on the student status table
+          const studentsMinusLastOne = students.slice(0, students.length - 1);
+          const updatedStudents = [data, ...studentsMinusLastOne];
+          setStudents(updatedStudents);
+        }
         setTotalCount(totalCount + 1);
 
-        // const totalPages = Math.ceil(totalCount / perPage);
+        const updatedTotalPages = Math.ceil((totalCount + 1) / perPage);
+        setTotalPages(updatedTotalPages);
+
+        setLastAddedStudentStatusID(data.id);
 
         setStudentInfo({
           first_name: "",
@@ -156,7 +156,7 @@ const FieldTripDetails = ({ match } ) => {
       });
   };
 
-  const onHandleCheckbox = async studentStatus => {
+  const onHandleCheckbox = studentStatus => {
     const clickedStudentStatusID = studentStatus.studentStatusID;
     const url = `students_fieldtrips/${clickedStudentStatusID}`;
 
@@ -194,6 +194,20 @@ const FieldTripDetails = ({ match } ) => {
 
     setStudents(updatedStudents);
   };
+
+  const onPaginationChange = (activePage) => {
+    const tripItemID = match.params.id;
+    const statusUrl = `students_fieldtrips/${tripItemID}/statuses?page=${activePage}`;
+    api
+      .get(statusUrl)
+      .then(({ data }) => {
+        console.log("students ALL::", data);
+        setStudents(data.completeStudentStatusesSorted);
+        setLastAddedStudentStatusID(null);
+        return setTotalCount(data.totalCount);
+      })
+      .catch(err => err);
+  }
 
   return (
     <>
@@ -252,6 +266,9 @@ const FieldTripDetails = ({ match } ) => {
           trip={trip}
           students={students}
           totalCount={totalCount}
+          totalPages={totalPages}
+          onPaginationChange={onPaginationChange}
+          lastAddedStudentStatusID={lastAddedStudentStatusID}
           parentList={parentList}
           setIsSuccessfullyAdded={setIsSuccessfullyAdded}
           isSuccessfullyAdded={isSuccessfullyAdded}

--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -20,6 +20,7 @@ const FieldTripDetails = ({ match } ) => {
 
   const [trip, setTrip] = useState({}); // local state
   const [students, setStudents] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
   const [chaperones, setChaperones] = useState([]);
   const [user] = useGlobal("user");
   const [parentList, setParentList] = useState([])
@@ -40,8 +41,9 @@ const FieldTripDetails = ({ match } ) => {
       .get(`students_fieldtrips/${tripItemID}/statuses`)
       .then(({ data }) => {
         console.log("ALL STATUS:", data);
-
-        return setStudents(data);
+        // {completeStudentStatusesSorted, totalCount, totalPages}
+        setStudents(data.completeStudentStatusesSorted);
+        return setTotalCount(data.totalCount);
       })
       .catch(err => err);
 
@@ -118,7 +120,8 @@ const FieldTripDetails = ({ match } ) => {
           .get(statusUrl)
           .then(({ data }) => {
             console.log("students ALL::", data);
-            return setStudents(data);
+            setStudents(data.completeStudentStatusesSorted);
+            return setTotalCount(data.totalCount);
           })
           .catch(err => err);
 
@@ -239,6 +242,7 @@ const FieldTripDetails = ({ match } ) => {
           studentInfo={studentInfo}
           trip={trip}
           students={students}
+          totalCount={totalCount}
           parentList={parentList}
           setIsSuccessfullyAdded={setIsSuccessfullyAdded}
           isSuccessfullyAdded={isSuccessfullyAdded}

--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -26,6 +26,8 @@ const FieldTripDetails = ({ match } ) => {
   const [parentList, setParentList] = useState([])
   const tripItemID = match.params.id;
 
+  let perPage;
+
   useEffect(() => {
     const url = `fieldtrips/${tripItemID}`
     api
@@ -43,7 +45,8 @@ const FieldTripDetails = ({ match } ) => {
         console.log("ALL STATUS:", data);
         // {completeStudentStatusesSorted, totalCount, totalPages}
         setStudents(data.completeStudentStatusesSorted);
-        return setTotalCount(data.totalCount);
+        setTotalCount(data.totalCount);
+        perPage = data.perPage;
       })
       .catch(err => err);
 
@@ -113,17 +116,23 @@ const FieldTripDetails = ({ match } ) => {
         setIsSuccessfullyAdded(true);
         setError(false);
 
-        const tripItemID = match.params.id;
-        const statusUrl = `students_fieldtrips/${tripItemID}/statuses`;
+        // const tripItemID = match.params.id;
+        // const statusUrl = `students_fieldtrips/${tripItemID}/statuses?sortBy=created_at&direction=desc`;
+        // api
+        //   .get(statusUrl)
+        //   .then(({ data }) => {
+        //     console.log("students ALL::", data);
+        //     setStudents(data.completeStudentStatusesSorted);
+        //     return setTotalCount(data.totalCount);
+        //   })
+        //   .catch(err => err);
 
-        api
-          .get(statusUrl)
-          .then(({ data }) => {
-            console.log("students ALL::", data);
-            setStudents(data.completeStudentStatusesSorted);
-            return setTotalCount(data.totalCount);
-          })
-          .catch(err => err);
+        const studentsMinusLastOne = students.slice(0, students.length - 1);
+        const updatedStudents = [data, ...studentsMinusLastOne];
+        setStudents(updatedStudents);
+        setTotalCount(totalCount + 1);
+
+        // const totalPages = Math.ceil(totalCount / perPage);
 
         setStudentInfo({
           first_name: "",

--- a/src/Components/FieldTrip/TeacherFieldTripDetailView.js
+++ b/src/Components/FieldTrip/TeacherFieldTripDetailView.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useGlobal } from "reactn";
 import {
   Button,
@@ -8,9 +8,10 @@ import {
   Icon,
   Message,
   Modal,
+  Pagination,
   Segment,
   Table,
-} from "semantic-ui-react";
+} from 'semantic-ui-react'
 import AddChaperoneModal from './AddChaperoneModal';
 import { MaybeCheckmarkWithWarning } from '../Shared/MaybeCheckmark';
 import getStatus from '../../Utils/getStatus';
@@ -23,6 +24,9 @@ const TeacherFieldTripDetailView = (
     studentInfo,
     students,
     totalCount,
+    totalPages,
+    onPaginationChange,
+    lastAddedStudentStatusID,
     parentList,
     setIsSuccessfullyAdded,
     isSuccessfullyAdded,
@@ -36,6 +40,7 @@ const TeacherFieldTripDetailView = (
     match,
   }) => {
   const [ user ] = useGlobal("user");
+  const [activePage, setActivePage] = useState(1);
 
   return (
     <>
@@ -121,7 +126,12 @@ const TeacherFieldTripDetailView = (
               </Modal>
             </Segment>
 
-            <Table columns={5} style={{ marginTop: 20, marginBottom: 50 }}>
+            <Segment size="big" attached="top">
+              {/*{5 of 10 attending*/} {totalCount} Total
+            </Segment>
+
+            <Table columns={5} style={{ marginBottom: 50 }} celled striped selectable attached="bottom">
+
               <Table.Header>
                 <Table.Row>
                   <Table.HeaderCell>First Name</Table.HeaderCell>
@@ -143,7 +153,13 @@ const TeacherFieldTripDetailView = (
                     const isComplete = status === 'complete';
 
                     return (
-                      <Table.Row key={student.id}>
+                      <Table.Row
+                        key={student.id}
+                        style={
+                          lastAddedStudentStatusID === student.id ?
+                            {backgroundColor: '#ebf5ff'} : undefined
+                        }
+                      >
                         <Table.Cell>{student.first_name}</Table.Cell>
                         <Table.Cell>{student.last_name}</Table.Cell>
                         <Table.Cell>
@@ -186,12 +202,22 @@ const TeacherFieldTripDetailView = (
 
               <Table.Footer>
                 <Table.Row>
-                  <Table.HeaderCell>{/*students.length*/} {totalCount} Students Going</Table.HeaderCell>
-                  <Table.HeaderCell />
-                  <Table.HeaderCell />
-                  <Table.HeaderCell />
-                  <Table.HeaderCell />
-                  <Table.HeaderCell />
+                  <Table.HeaderCell colSpan='6'>
+                    <Pagination
+                      floated='right'
+                      boundaryRange={0}
+                      activePage={activePage}
+                      onPageChange={(e, data) => {
+                        onPaginationChange(data.activePage);
+                        setActivePage(data.activePage);
+                      }}
+                      firstItem={null}
+                      lastItem={null}
+                      siblingRange={1}
+                      totalPages={totalPages}
+                      size='mini'
+                    />
+                  </Table.HeaderCell>
                 </Table.Row>
               </Table.Footer>
             </Table>

--- a/src/Components/FieldTrip/TeacherFieldTripDetailView.js
+++ b/src/Components/FieldTrip/TeacherFieldTripDetailView.js
@@ -22,6 +22,7 @@ const TeacherFieldTripDetailView = (
     chaperonesToAssign,
     studentInfo,
     students,
+    totalCount,
     parentList,
     setIsSuccessfullyAdded,
     isSuccessfullyAdded,
@@ -113,7 +114,7 @@ const TeacherFieldTripDetailView = (
                         {parentList.map(parent => <option key={parent.id} value={parent.id}>
                         {`${parent.last_name}, ${parent.first_name}`}
                       </option>)}
-                    </Form.Field>        
+                    </Form.Field>
                     <Form.Button primary>Submit</Form.Button>
                   </Form>
                 </Modal.Content>
@@ -185,7 +186,7 @@ const TeacherFieldTripDetailView = (
 
               <Table.Footer>
                 <Table.Row>
-                  <Table.HeaderCell>{students.length} Students Going</Table.HeaderCell>
+                  <Table.HeaderCell>{/*students.length*/} {totalCount} Students Going</Table.HeaderCell>
                   <Table.HeaderCell />
                   <Table.HeaderCell />
                   <Table.HeaderCell />


### PR DESCRIPTION
This PR adds the following features to the student status table (**[please see the related Backend PR**](https://github.com/field-trip-planner/Backend/pull/34)):

- working pagination functionality
- highlighting to row & move to top when a new student is added
- sort students by last name (default)

<img width="970" alt="status_tablePagination" src="https://user-images.githubusercontent.com/7329185/66449026-9a983f00-ea21-11e9-9fd0-8e3090468f63.png">
