### PR TITLE
Feature- sort student status table

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "fuse.js": "^3.4.5",
+    "lodash": "^4.17.15",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-router-dom": "^5.0.1",

--- a/src/Components/CreateTripModal/index.js
+++ b/src/Components/CreateTripModal/index.js
@@ -122,14 +122,14 @@ const CreateTripModal = props => {
                     name="field_trip_details"
                     value={fieldTripInfo.field_trip_details}
                     onChange={_handleChange}
-                    width=""
+
                   />
                   <Form.TextArea
                     label="Chaperone Tasks"
                     name="chaperoneTasks"
                     value={fieldTripInfo.chaperoneTasks}
                     onChange={_handleChange}
-                    width=""
+
                   />
                 </Form.Group>
                 <Form.Button primary>Submit</Form.Button>

--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -187,13 +187,12 @@ const FieldTripDetails = ({ match }) => {
   };
 
   const onPaginationChange = activePage => {
-    const newDirection = direction === "ascending" ? "asc" : "desc";
-    const statusUrl = `students_fieldtrips/${tripItemID}/statuses?page=${activePage}&sortBy=${sortBy}&direction=${newDirection}`;
+    const shortDirection = shortenDirection(direction);
+    const statusUrl = `students_fieldtrips/${tripItemID}/statuses?page=${activePage}&sortBy=${sortBy}&direction=${shortDirection}`;
 
     api()
       .get(statusUrl)
       .then(({ data }) => {
-        console.log("students ALL::", data);
         setStudents(data.completeStudentStatusesSorted);
         setLastAddedStudentStatusID(null);
         return setTotalCount(data.totalCount);
@@ -231,24 +230,19 @@ const FieldTripDetails = ({ match }) => {
       'descending' : 'ascending';
   };
 
-  const handleSort = (clickedColumn, activePage) => () => {
-    console.log("clickedColumn::", clickedColumn);
-    console.log("Previous Column/sortBy::", sortBy);
+  function shortenDirection (newDirection) {
+    return newDirection === "ascending" ? "asc" : "desc";
+  }
 
+  const handleSort = (clickedColumn, activePage) => () => {
     if (sortBy !== clickedColumn) {
       setSortBy(clickedColumn);
     }
     const newDirection = getDirection(clickedColumn);
     setDirection(newDirection);
+    const shortDirection = shortenDirection(newDirection);
 
-    console.log("newDirection::", newDirection);
-    console.log("New Column/sortBy::", sortBy);
-    console.log("activePage::", activePage);
-
-    const newDirectionURL = newDirection === "ascending" ? "asc" : "desc";
-    console.log("newDirectionForBE::", newDirectionURL);
-
-    const statusUrl = `students_fieldtrips/${tripItemID}/statuses?page=${activePage}&sortBy=${clickedColumn}&direction=${newDirectionURL}`;
+    const statusUrl = `students_fieldtrips/${tripItemID}/statuses?page=${activePage}&sortBy=${clickedColumn}&direction=${shortDirection}`;
 
     api()
       .get(statusUrl)

--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -9,6 +9,7 @@ import ChaperoneFieldTripDetailView from "./ChaperoneFieldTripDetailView";
 import StudentsReadOnlyTable from "./StudentsReadOnlyTable";
 import ChaperonesTable from "./ChaperonesTable";
 import "./FieldTripDetails.css";
+import { sortBy as _sortBy } from 'lodash';
 
 let perPage;
 const FieldTripDetails = ({ match }) => {
@@ -23,6 +24,8 @@ const FieldTripDetails = ({ match }) => {
   const [user] = useGlobal("user");
   const [parentList, setParentList] = useState([]);
   const tripItemID = match.params.id;
+  const [sortBy, setSortBy] = useState("last_name");
+  const [direction, setDirection] = useState("ascending");
 
   useEffect(() => {
     const url = `fieldtrips/${tripItemID}`;
@@ -186,7 +189,10 @@ const FieldTripDetails = ({ match }) => {
 
   const onPaginationChange = activePage => {
     const tripItemID = match.params.id;
-    const statusUrl = `students_fieldtrips/${tripItemID}/statuses?page=${activePage}`;
+
+    const newDirection = direction === "ascending" ? "asc" : "desc";
+    const statusUrl = `students_fieldtrips/${tripItemID}/statuses?page=${activePage}&sortBy=${sortBy}&direction=${newDirection}`;
+
     api()
       .get(statusUrl)
       .then(({ data }) => {
@@ -219,6 +225,25 @@ const FieldTripDetails = ({ match }) => {
       })
       .catch(err => err);
   };
+
+  const handleSort = (clickedColumn) => () => {
+    if (sortBy !== clickedColumn) {
+      const studentsSorted = _sortBy(students, [clickedColumn]);
+
+      setStudents(studentsSorted);
+      setSortBy(clickedColumn);
+      setDirection('ascending');
+
+      return;
+    }
+    // when clicking same column that you've sorted before
+    const studentsSortedReversed = students.reverse();
+    const newDirection = direction === 'ascending' ?
+      'descending' : 'ascending';
+
+    setDirection(newDirection);
+    setStudents(studentsSortedReversed);
+  }
 
   return (
     <>
@@ -273,6 +298,9 @@ const FieldTripDetails = ({ match }) => {
           students={students}
           totalCount={totalCount}
           totalPages={totalPages}
+          handleSort={handleSort}
+          sortBy={sortBy}
+          direction={direction}
           onPaginationChange={onPaginationChange}
           onDeleteMessageConfirmation={onDeleteMessageConfirmation}
           lastAddedStudentStatusID={lastAddedStudentStatusID}

--- a/src/Components/FieldTrip/TeacherFieldTripDetailView.js
+++ b/src/Components/FieldTrip/TeacherFieldTripDetailView.js
@@ -146,13 +146,13 @@ const TeacherFieldTripDetailView = (
                 <Table.Row>
                   <Table.HeaderCell
                     sorted={sortBy === 'first_name' ? direction : null}
-                    onClick={handleSort('first_name')}
+                    onClick={handleSort('first_name', activePage)}
                   >
                     First Name
                   </Table.HeaderCell>
                   <Table.HeaderCell
                     sorted={sortBy === 'last_name' ? direction : null}
-                    onClick={handleSort('last_name')}
+                    onClick={handleSort('last_name', activePage)}
                   >
                     Last Name
                   </Table.HeaderCell>
@@ -174,7 +174,7 @@ const TeacherFieldTripDetailView = (
                   <Table.HeaderCell
                     collapsing
                     sorted={sortBy === 'going_status' ? direction : null}
-                    onClick={handleSort('going_status')}
+                    onClick={handleSort('going_status', activePage)}
                   >
                     Status
                   </Table.HeaderCell>

--- a/src/Components/FieldTrip/TeacherFieldTripDetailView.js
+++ b/src/Components/FieldTrip/TeacherFieldTripDetailView.js
@@ -26,6 +26,9 @@ const TeacherFieldTripDetailView = (
     students,
     totalCount,
     totalPages,
+    handleSort,
+    sortBy,
+    direction,
     onPaginationChange,
     onDeleteMessageConfirmation,
     lastAddedStudentStatusID,
@@ -132,11 +135,27 @@ const TeacherFieldTripDetailView = (
               {/*{5 of 10 attending*/} {totalCount} Total
             </Segment>
 
-            <Table style={{marginBottom: 50}} celled striped selectable attached="bottom">
+            <Table style={{marginBottom: 50}}
+                   celled
+                   striped
+                   selectable
+                   attached="bottom"
+                   sortable
+            >
               <Table.Header>
                 <Table.Row>
-                  <Table.HeaderCell>First Name</Table.HeaderCell>
-                  <Table.HeaderCell>Last Name</Table.HeaderCell>
+                  <Table.HeaderCell
+                    sorted={sortBy === 'first_name' ? direction : null}
+                    onClick={handleSort('first_name')}
+                  >
+                    First Name
+                  </Table.HeaderCell>
+                  <Table.HeaderCell
+                    sorted={sortBy === 'last_name' ? direction : null}
+                    onClick={handleSort('last_name')}
+                  >
+                    Last Name
+                  </Table.HeaderCell>
                   <Table.HeaderCell collapsing>
                     <div style={{ width: 70 }}>
                       Paid
@@ -152,7 +171,13 @@ const TeacherFieldTripDetailView = (
                       Supplies
                     </div>
                   </Table.HeaderCell>
-                  <Table.HeaderCell collapsing>Status</Table.HeaderCell>
+                  <Table.HeaderCell
+                    collapsing
+                    sorted={sortBy === 'going_status' ? direction : null}
+                    onClick={handleSort('going_status')}
+                  >
+                    Status
+                  </Table.HeaderCell>
                   <Table.HeaderCell collapsing >Delete</Table.HeaderCell>
                 </Table.Row>
               </Table.Header>


### PR DESCRIPTION
This PR adds the following feature(s):

- sort by either last/first name or going_status columns
- sorts entire student status list no matter what page the user is currently on from the pagination