### PR TITLE
[WIP] Feature- search from the trip status table

### DIFF
--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -46,13 +46,13 @@ const FieldTripDetails = ({ match }) => {
         console.log("ALL STATUS:", data);
         const {
           completeStudentStatusesSorted,
-          numberOfIncompleteStatus,
+          statusIncompleteCount,
           totalCount,
           totalPages
         } = data;
         setStudents(completeStudentStatusesSorted);
         setTotalCount(totalCount);
-        setStatusIncompleteCount(numberOfIncompleteStatus);
+        setStatusIncompleteCount(statusIncompleteCount);
         setTotalPages(totalPages);
         perPage = data.perPage;
       })
@@ -265,9 +265,7 @@ const FieldTripDetails = ({ match }) => {
 
   const onKeyDownSearchChange = (e) => {
     const { value } = e.target;
-    console.log("SEARCH-VALUE::", value);
-    setQuery(value)
-    console.log("SEARCH-STUDENT-QUERY::", query);
+    setQuery(value);
 
     if (!value) {
       api()

--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -298,6 +298,24 @@ const FieldTripDetails = ({ match }) => {
       .catch(err => err);
   }
 
+  const onSearchClear = () => {
+    setQuery("");
+    api()
+      .get(`students_fieldtrips/${tripItemID}/statuses`)
+      .then(({ data }) => {
+        const {completeStudentStatusesSorted, totalCount, totalPages} = data;
+        setStudents(completeStudentStatusesSorted);
+        setTotalCount(totalCount);
+        setTotalPages(totalPages);
+
+        // resetting state to default
+        setSortBy("last_name");
+        direction("ascending");
+        setActivePage(1);
+      })
+      .catch(err => err);
+  }
+
   return (
     <>
       {/* trip is our local state data */}
@@ -356,6 +374,7 @@ const FieldTripDetails = ({ match }) => {
           handleSort={handleSort}
           onKeyDownSearchChange={onKeyDownSearchChange}
           query={query}
+          onSearchClear={onSearchClear}
           sortBy={sortBy}
           direction={direction}
           onPaginationChange={onPaginationChange}

--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -25,6 +25,7 @@ const FieldTripDetails = ({ match }) => {
   const tripItemID = match.params.id;
   const [sortBy, setSortBy] = useState("last_name");
   const [direction, setDirection] = useState("ascending");
+  const [activePage, setActivePage] = useState(1);
 
   useEffect(() => {
     const url = `fieldtrips/${tripItemID}`;
@@ -254,6 +255,8 @@ const FieldTripDetails = ({ match }) => {
       .catch(err => err);
   }
 
+  // Add Search method here
+
   return (
     <>
       {/* trip is our local state data */}
@@ -307,6 +310,8 @@ const FieldTripDetails = ({ match }) => {
           students={students}
           totalCount={totalCount}
           totalPages={totalPages}
+          activePage={activePage}
+          setActivePage={setActivePage}
           handleSort={handleSort}
           sortBy={sortBy}
           direction={direction}

--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -15,6 +15,7 @@ const FieldTripDetails = ({ match }) => {
   const [trip, setTrip] = useState({}); // local state
   const [students, setStudents] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
+  const [statusIncompleteCount, setStatusIncompleteCount] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [lastAddedStudentStatusID, setLastAddedStudentStatusID] = useState(
     null
@@ -43,10 +44,16 @@ const FieldTripDetails = ({ match }) => {
       .get(`students_fieldtrips/${tripItemID}/statuses`)
       .then(({ data }) => {
         console.log("ALL STATUS:", data);
-        // {completeStudentStatusesSorted, totalCount, totalPages}
-        setStudents(data.completeStudentStatusesSorted);
-        setTotalCount(data.totalCount);
-        setTotalPages(data.totalPages);
+        const {
+          completeStudentStatusesSorted,
+          numberOfIncompleteStatus,
+          totalCount,
+          totalPages
+        } = data;
+        setStudents(completeStudentStatusesSorted);
+        setTotalCount(totalCount);
+        setStatusIncompleteCount(numberOfIncompleteStatus);
+        setTotalPages(totalPages);
         perPage = data.perPage;
       })
       .catch(err => err);
@@ -367,6 +374,7 @@ const FieldTripDetails = ({ match }) => {
           studentInfo={studentInfo}
           trip={trip}
           students={students}
+          statusIncompleteCount={statusIncompleteCount}
           totalCount={totalCount}
           totalPages={totalPages}
           activePage={activePage}

--- a/src/Components/FieldTrip/TeacherFieldTripDetailView.js
+++ b/src/Components/FieldTrip/TeacherFieldTripDetailView.js
@@ -27,7 +27,11 @@ const TeacherFieldTripDetailView = (
     students,
     totalCount,
     totalPages,
+    activePage,
+    setActivePage,
     handleSort,
+    onKeyDownSearchChange,
+    query,
     sortBy,
     direction,
     onPaginationChange,
@@ -46,7 +50,6 @@ const TeacherFieldTripDetailView = (
     match,
   }) => {
   const [ user ] = useGlobal("user");
-  const [activePage, setActivePage] = useState(1);
 
   return (
     <>
@@ -145,7 +148,8 @@ const TeacherFieldTripDetailView = (
                 iconPosition='left'
                 placeholder='Search a student...'
                 size="mini"
-                onChange={() => {}}
+                value={query}
+                onChange={onKeyDownSearchChange}
               />
             </Segment>
 

--- a/src/Components/FieldTrip/TeacherFieldTripDetailView.js
+++ b/src/Components/FieldTrip/TeacherFieldTripDetailView.js
@@ -25,6 +25,7 @@ const TeacherFieldTripDetailView = (
     chaperonesToAssign,
     studentInfo,
     students,
+    statusIncompleteCount,
     totalCount,
     totalPages,
     activePage,
@@ -141,9 +142,11 @@ const TeacherFieldTripDetailView = (
               size="big"
               attached="top"
             >
-              <span>
-                {totalCount} Total
-              </span>
+              <Header
+                as='h3'
+                content={`${totalCount} Total`}
+                subheader={!query && `${statusIncompleteCount} of ${totalCount} with incomplete status`}
+              />
               <Input
                 icon={{ name: 'search' }}
                 iconPosition='left'

--- a/src/Components/FieldTrip/TeacherFieldTripDetailView.js
+++ b/src/Components/FieldTrip/TeacherFieldTripDetailView.js
@@ -6,6 +6,7 @@ import {
   Form,
   Header,
   Icon,
+  Input,
   Message,
   Modal,
   Pagination,
@@ -131,8 +132,21 @@ const TeacherFieldTripDetailView = (
               </Modal>
             </Segment>
 
-            <Segment size="big" attached="top">
-              {/*{5 of 10 attending*/} {totalCount} Total
+            <Segment
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}
+              size="big"
+              attached="top"
+            >
+              <span>
+                {totalCount} Total
+              </span>
+              <Input
+                icon={{ name: 'search' }}
+                iconPosition='left'
+                placeholder='Search a student...'
+                size="mini"
+                onChange={() => {}}
+              />
             </Segment>
 
             <Table style={{marginBottom: 50}}

--- a/src/Components/FieldTrip/TeacherFieldTripDetailView.js
+++ b/src/Components/FieldTrip/TeacherFieldTripDetailView.js
@@ -32,6 +32,7 @@ const TeacherFieldTripDetailView = (
     handleSort,
     onKeyDownSearchChange,
     query,
+    onSearchClear,
     sortBy,
     direction,
     onPaginationChange,
@@ -146,6 +147,11 @@ const TeacherFieldTripDetailView = (
               <Input
                 icon={{ name: 'search' }}
                 iconPosition='left'
+                action={
+                  <Button onClick={onSearchClear}
+                          icon='cancel'
+                  />
+                }
                 placeholder='Search a student...'
                 size="mini"
                 value={query}


### PR DESCRIPTION
This PR ([related to Backend PR# 38](https://github.com/field-trip-planner/Backend/pull/38)) adds the following feature(s):

- search for a specific student on keyDown by first or last name
- a sortable result list is still displayed as each matching query character is typed in search field until the student is found
- clear any search input entry on click of button
- display count of incomplete statuses (hides when search query is active)
- display a student not found message view
