### PR TITLE
update trip status table empty view & fix incomplete status count

### DIFF
--- a/src/Components/FieldTrip/FieldTripDetails.js
+++ b/src/Components/FieldTrip/FieldTripDetails.js
@@ -137,6 +137,7 @@ const FieldTripDetails = ({ match }) => {
         setTotalPages(updatedTotalPages);
 
         setLastAddedStudentStatusID(data.id);
+        setStatusIncompleteCount(statusIncompleteCount + 1);
 
         setStudentInfo({
           first_name: "",

--- a/src/Components/FieldTrip/TeacherFieldTripDetailView.js
+++ b/src/Components/FieldTrip/TeacherFieldTripDetailView.js
@@ -18,6 +18,18 @@ import AddChaperoneModal from './AddChaperoneModal';
 import { MaybeCheckmarkWithWarning } from '../Shared/MaybeCheckmark';
 import getStatus from '../../Utils/getStatus';
 
+const EmptyView = ({children}) => {
+  return (
+    <Table.Row>
+      <Table.Cell textAlign="center" colSpan="7">
+        <div style={{padding: 20, fontSize: 16}}>
+          {children}
+        </div>
+      </Table.Cell>
+    </Table.Row>
+  )
+}
+
 const TeacherFieldTripDetailView = (
   { setStudentInfo,
     setChaperones,
@@ -52,6 +64,24 @@ const TeacherFieldTripDetailView = (
     match,
   }) => {
   const [ user ] = useGlobal("user");
+  const isOrAre = statusIncompleteCount > 1 ? 'are' : 'is';
+
+  const getEmptyView = () => {
+    if (!students.length) {
+      if (query) {
+        return (
+          <EmptyView>
+            Sorry, no students were found!
+          </EmptyView>
+        )
+      }
+      return (
+        <EmptyView>
+          So far, no attendees.
+        </EmptyView>
+      )
+    }
+  }
 
   return (
     <>
@@ -145,7 +175,7 @@ const TeacherFieldTripDetailView = (
               <Header
                 as='h3'
                 content={`${totalCount} Total`}
-                subheader={!query && `${statusIncompleteCount} are incomplete`}
+                subheader={!query && `${statusIncompleteCount} ${isOrAre} incomplete`}
                 style={{marginBottom: 0}}
               />
               <Input
@@ -211,16 +241,7 @@ const TeacherFieldTripDetailView = (
               </Table.Header>
 
               <Table.Body>
-                {
-                  !students.length &&
-                   <Table.Row>
-                      <Table.Cell textAlign="center" colSpan="7">
-                        <div style={{padding: 20, fontSize: 16}}>
-                          Sorry, no students were found
-                        </div>
-                      </Table.Cell>
-                    </Table.Row>
-                }
+                { getEmptyView() }
                 {
                   students.map((student) => {
                     const status = getStatus(student);


### PR DESCRIPTION
This PR does the following:

- correct empty view displays based on search results vs when there are no students yet added to a trip
- fix: incomplete status count shows correct number when a new student is added
- fix: correct verb displays when this count is 1 or more.
<br>

*Below is the view when no students have not yet been added to a trip*

---

<img width="971" alt="trip_status_emptyView" src="https://user-images.githubusercontent.com/7329185/67052353-df9c2f80-f10b-11e9-8eb3-af8bf1848976.png">